### PR TITLE
Remove leftover env in filterconfig

### DIFF
--- a/src/utils/filterconfig.ts
+++ b/src/utils/filterconfig.ts
@@ -1,5 +1,3 @@
-'NEXT_PUBLIC_API_BASE_URL=http://localhost:7000;'
-
 export const filterConfig = [
   { name: "newCategoryId", label: "Category", api: `/api/newcategory/viewcategory` },
   { name: "structureId", label: "Structure", api: `/api/structure/view` },


### PR DESCRIPTION
## Summary
- clean up `filterconfig.ts` by removing the unused base URL line

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8e72e870832aa32d7700f37bcbd4